### PR TITLE
Fix: Progress bar not resetting after skip

### DIFF
--- a/src/components/RandomWord.js
+++ b/src/components/RandomWord.js
@@ -81,7 +81,8 @@ const RandomWord = ({ words, isRunning, setIsRunning, timer, customization, show
         if (prev <= 1) {
           if (isRunning) {
             pickAndDisplayWord();
-            return durationInSeconds;
+            startNewCycle();
+            return timer * 60;
           }
           return prev;
         }


### PR DESCRIPTION
This commit fixes a bug where the progress bar would not reappear for a new word if that word was triggered by the timer expiring after a 'skip' action.

The issue was that the `skip` function had its own `setInterval` logic that was inconsistent with the main timer loop. It was missing a call to `startNewCycle()`, which is responsible for resetting the progress bar.

The `setInterval` callback within the `skip` function has been updated to call `startNewCycle()`, ensuring the progress bar resets correctly in all cases.